### PR TITLE
Made subscription id parameter mandatory

### DIFF
--- a/Az.Avd/Public/Connect-Avd.ps1
+++ b/Az.Avd/Public/Connect-Avd.ps1
@@ -41,7 +41,7 @@ function Connect-Avd {
         [ValidateNotNullOrEmpty()]
         [string]$RedirectUri = [string]::Empty,
 
-        [parameter(Mandatory, HelpMessage = "Specify the subscription ID to connect to")]
+        [parameter(HelpMessage = "Specify the subscription ID to connect to, this sets the context to the correct subscription directly. Otherwise, use Set-AvdContext -subscription")]
         [ValidateNotNullOrEmpty()]
         [string]$SubscriptionId,
 


### PR DESCRIPTION
Removed mandatory part for subscription id. It is now possible to login without a subscription id set. This is useful when looping over multiple subscriptions and avoids connecting every time to the correct subscription. 